### PR TITLE
Correct ad sp show command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We'll set up an Azure Subscription and our service principal. You can learn more
     Azure comes with a [free trial](https://azure.microsoft.com/en-us/free/) that includes $200 of free credit. 
 
 
-2. . Get the Azure CLI
+2. Get the Azure CLI
 
     ```
     npm i -g azure-cli
@@ -51,7 +51,7 @@ We'll set up an Azure Subscription and our service principal. You can learn more
     azure ad sp create -n <name> -p <password>
     ```
 
-    This should return an object which has the `servicePrincipalNames` property on it and an ObjectId. Save the Object Id and one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
+    This should return an object which has the `servicePrincipalNames` property on it and an ObjectId. Save the Object Id and one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp show -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
 
     Then grant the SP contributor access with the ObjectId
 


### PR DESCRIPTION
When trying to retrieve a service principal an error occurs:

```
% azure ad sp -c my-app
error:   '-c' is not an azure command. See 'azure help'
```
It appears it should be: `azure ad sp show -c my-app`

The [blog article](https://blogs.msdn.microsoft.com/appserviceteam/2017/02/23/azure-functions-support-for-serverless-framework/) is also incorrect here. Also, this article has two step 1's in the "Set up credentials" section. And the invoke command is incorrect:

```
  % serverless invoke function -f httpjs

  WARNING: You are running v1.7.0. v1.8.0 will include the following breaking changes:
    - Will replace IamPolicyLambdaExecution resource with inline policies -> https://git.io/vDilm
    - "sls info" will output the short function name rather than the lambda name -> https://git.io/vDiWx

  You can opt-out from these warnings by setting the "SLS_IGNORE_WARNING=*" environment variable.

 
  Serverless Error ---------------------------------------
 
     Command "invoke function" not found, Run "serverless
     help" for a list of all available commands.
 
  Stack Trace --------------------------------------------
 
ServerlessError: Command "invoke function" not found, Run "serverless help" for a list of all available commands
```

Appears it should be: `serverless invoke -f httpjs`
